### PR TITLE
Add validation error handling for blog post forms

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -3,7 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\Post;
-use Illuminate\Http\Request;
+// use Illuminate\Http\Request;
+use App\Http\Requests\PostRequest;
 
 class PostController extends Controller
 {
@@ -33,7 +34,7 @@ class PostController extends Controller
          return view('posts.create');
      }
      
-     public function store(Request $request, Post $post)
+     public function store(Post $post, PostRequest $request)  
      {
          $input = $request['post'];
          $post->fill($input)->save();

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'post.title' => 'required|string|max:100',
+            'post.body' => 'required|string|max:4000',
+        ];
+    }
+}

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -10,13 +10,15 @@
             @csrf
             <div class="title">
                 <h2>Title</h2>
-                <input type="text" name="post[title]" placeholder="タイトル"/>
+                <input type="text" name="post[title]" placeholder="タイトル" value="{{ old('post.title') }}"/>
+                <p class="title_error" style="color:red">{{ $errors->first('post.title') }}</p>
             </div>
             <div class="body">
                 <h2>Body</h2>
-                <textarea name="post[body]" placeholder="今日も1日お疲れさまでした。"></textarea>
+                <textarea name="post[body]" placeholder="今日も1日お疲れさまでした。">{{ old('post.body') }}</textarea>
+                <p class="body_error" style="color:red">{{ $errors->first('post.body') }}</p>
             </div>
-            <input type="submit" value="store"/>
+            <input type="submit" value="保存"/>
         </form>
         <div class="footer">
             <a href="/">戻る</a>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -12,7 +12,7 @@
             {{ $post->title }} 
         </h1>
         <div class="content">
-            <div class="content_post">
+            <div class="content__post">
                 <h3>本文</h3>
                 <p>{{ $post->body }}</p>
             </div>


### PR DESCRIPTION
This commit adds functionality to handle validation errors when submitting blog post forms. Validation rules are defined in the PostRequest class, and error messages are displayed to users when form data doesn't meet the required criteria. Additionally, the view files have been updated to display error messages appropriately.

※上記はChatGPTに考えてもらったコメント。